### PR TITLE
Add default systemPropertyVariables for failsafe and surefire plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,31 @@
         </configuration>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+                <maven.repo>${settings.localRepository}</maven.repo>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                <maven.home>${maven.home}</maven.home>
+                <maven.repo>${settings.localRepository}</maven.repo>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <profiles>
     <profile>


### PR DESCRIPTION
This is to avoid having to configure those in all the quarkiverse extensions and be closer to the quarkus-parent ones.