### PR TITLE
Add asciidoctor plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
     <!-- Default properties -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+    <!-- Documentation -->
+    <version.asciidoctorj>2.4.3</version.asciidoctorj>
+    <version.asciidoctor.plugin>2.1.0</version.asciidoctor.plugin>
   </properties>
 
   <licenses>
@@ -146,26 +149,80 @@
     </plugins>
     <pluginManagement>
       <plugins>
-          <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <systemPropertyVariables>
-                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                <maven.home>${maven.home}</maven.home>
-                <maven.repo>${settings.localRepository}</maven.repo>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <configuration>
-              <systemPropertyVariables>
-                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                <maven.home>${maven.home}</maven.home>
-                <maven.repo>${settings.localRepository}</maven.repo>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              <maven.home>${maven.home}</maven.home>
+              <maven.repo>${settings.localRepository}</maven.repo>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+              <maven.home>${maven.home}</maven.home>
+              <maven.repo>${settings.localRepository}</maven.repo>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <!-- Standalone doc artifact, and dry-run for Antora build of https://github.com/quarkiverse/quarkiverse-docs -->
+        <plugin>
+          <groupId>org.asciidoctor</groupId>
+          <artifactId>asciidoctor-maven-plugin</artifactId>
+          <version>${version.asciidoctor.plugin}</version>
+          <configuration>
+            <skip>${skipDocs}</skip>
+            <enableVerbose>true</enableVerbose>
+            <logHandler>
+              <failIf>
+                <severity>WARN</severity>
+              </failIf>
+            </logHandler>
+            <sourceDirectory>${project.basedir}/modules/ROOT/pages/</sourceDirectory>
+            <preserveDirectories>true</preserveDirectories>
+            <attributes>
+              <icons>font</icons>
+              <!-- Antora images path -->
+              <imagesdir>./_images/</imagesdir>
+              <sectanchors>true</sectanchors>
+              <!-- set the idprefix to blank -->
+              <idprefix />
+              <idseparator>-</idseparator>
+              <docinfo1>true</docinfo1>
+              <!-- avoid content security policy violations -->
+              <skip-front-matter>true</skip-front-matter>
+            </attributes>
+          </configuration>
+          <executions>
+            <execution>
+              <id>output-html</id>
+              <phase>prepare-package</phase>
+              <goals>
+                <goal>process-asciidoc</goal>
+              </goals>
+              <configuration>
+                <backend>html5</backend>
+                <attributes>
+                  <source-highlighter>coderay</source-highlighter>
+                  <!-- avoid content security policy violations -->
+                  <linkcss>true</linkcss>
+                  <copycss>true</copycss>
+                </attributes>
+              </configuration>
+            </execution>
+          </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.asciidoctor</groupId>
+              <artifactId>asciidoctorj</artifactId>
+              <version>${version.asciidoctorj}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Fixes #19

I've tested the parent pom locally on quarkus-logging-splunk.

It allows to:

- easily build a standalone documentation of the extension.
- dry-run what will be built during the quarkus-docs Antora build (aligning asciidoctor config with the one of Antora, to be as close as possible).

The asciidoctor plugin still needs to be explicitly added to the docs Maven sub-module of the extension:

```xml
<build>
  <plugins>
    <plugin>
      <groupId>org.asciidoctor</groupId>
      <artifactId>asciidoctor-maven-plugin</artifactId>
    </plugin>
  </plugins>
</build>
```