### PR TITLE
Add Quarkus developers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,15 @@
     <url>https://github.com/quarkusio/quarkus/issues</url>
   </issueManagement>
 
+  <developers>
+    <developer>
+      <id>quarkiverse</id>
+      <name>Quarkiverse Community</name>
+      <organization>Quarkiverse</organization>
+      <organizationUrl>https://quarkiverse.io</organizationUrl>
+    </developer>
+  </developers>
+
   <scm>
     <connection>scm:git:git@github.com:quarkiverse/quarkiverse-parent.git</connection>
     <developerConnection>scm:git:git@github.com:quarkiverse/quarkiverse-parent.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -89,10 +89,8 @@
 
   <developers>
     <developer>
-      <id>quarkiverse</id>
-      <name>Quarkiverse Community</name>
-      <organization>Quarkiverse</organization>
-      <organizationUrl>https://quarkiverse.io</organizationUrl>
+      <id>quarkus</id>
+      <name>Quarkus Community</name>
     </developer>
   </developers>
 


### PR DESCRIPTION
Central requires a `<developers>` tag, otherwise release fails with: 

```
Error: [ERROR] Rule failure while trying to close staging repository with ID "ioquarkiverse-1958".
Error: [ERROR]
Error: [ERROR] Nexus Staging Rules Failure Report
Error: [ERROR] ==================================
Error: [ERROR]
Error: [ERROR] Repository "ioquarkiverse-1958" failures
Error: [ERROR]   Rule "pom-staging" failures
Error: [ERROR]     * Invalid POM: /io/quarkiverse/quarkiverse-parent/13/quarkiverse-parent-13.pom: Developer information missing
```