### PR TITLE
Add RAG profile for extensions to contribute documentation embeddings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <!-- Plugin versions (please keep in alphabetical order) -->
     <version.buildhelper.plugin>3.6.1</version.buildhelper.plugin>
+    <version.documentation-rag.plugin>0.0.2</version.documentation-rag.plugin>
     <version.buildnumber.plugin>3.3.0</version.buildnumber.plugin>
     <version.clean.plugin>3.5.0</version.clean.plugin>
     <version.compiler.plugin>3.15.0</version.compiler.plugin>
@@ -454,6 +455,11 @@
           <artifactId>flatten-maven-plugin</artifactId>
           <version>${version.flatten.plugin}</version>
         </plugin>
+        <plugin>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+          <version>${version.documentation-rag.plugin}</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -551,6 +557,30 @@
                 <phase>package</phase>
                 <goals>
                   <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>rag</id>
+      <activation>
+        <property>
+          <name>rag</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-extension-rag</id>
+                <goals>
+                  <goal>generate-rag</goal>
                 </goals>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <!-- Plugin versions (please keep in alphabetical order) -->
     <version.buildhelper.plugin>3.6.1</version.buildhelper.plugin>
-    <version.documentation-rag.plugin>0.0.2</version.documentation-rag.plugin>
+    <version.documentation-rag.plugin>0.0.3</version.documentation-rag.plugin>
     <version.buildnumber.plugin>3.3.0</version.buildnumber.plugin>
     <version.clean.plugin>3.5.0</version.clean.plugin>
     <version.compiler.plugin>3.15.0</version.compiler.plugin>


### PR DESCRIPTION
Adds a `-Prag` profile with the [quarkus-documentation-rag](https://github.com/quarkusio/quarkus-documentation-rag) Maven plugin. This lets Quarkiverse extensions contribute their documentation to the Quarkus AI assistant's vector store.

Extensions opt in by setting a single property in their deployment POM:

```xml
<properties>
    <quarkus-rag.guide>docs/modules/ROOT/pages/index.adoc</quarkus-rag.guide>
</properties>
```

The plugin automatically uses `${project.artifactId}` as the source name and silently skips modules where the property is not set, so extensions that don't have docs are unaffected.

When activated (`mvn install -Prag`), the plugin processes the AsciiDoc guide into vector embeddings (BGE Small EN v1.5, 384 dimensions) and outputs `META-INF/quarkus-rag.sql` in the deployment JAR. This SQL is discovered at runtime by `quarkus-agent-mcp` and `chappie-server` for documentation search.